### PR TITLE
Change in Twitch Channel Subscriptions Event Message Sub Plan

### DIFF
--- a/js/streamlabs/streamlabsHandler.js
+++ b/js/streamlabs/streamlabsHandler.js
@@ -185,7 +185,7 @@ class StreamlabsHandler extends Handler {
       'user': message.name,
       'gifter': gifter,
       'months': message.months,
-      'tier': message.subPlan === 'Prime' ? 'Prime' : 'Tier ' + (parseInt(message.subPlan) / 1000)
+      'tier': message.sub_plan === 'Prime' ? 'Prime' : 'Tier ' + (parseInt(message.sub_plan) / 1000)
     }
   }
 
@@ -202,7 +202,7 @@ class StreamlabsHandler extends Handler {
       'data': message,
       'amount': message.amount,
       'gifter': gifter,
-      'tier': message.subPlan === 'Prime' ? 'Prime' : 'Tier ' + (parseInt(message.subPlan) / 1000)
+      'tier': message.sub_plan === 'Prime' ? 'Prime' : 'Tier ' + (parseInt(message.sub_plan) / 1000)
     }
   }
 
@@ -240,7 +240,7 @@ class StreamlabsHandler extends Handler {
       'user': message.name,
       'months': message.months,
       'message': message.message,
-      'tier': message.subPlan === 'Prime' ? 'Prime' : 'Tier ' + (parseInt(message.subPlan) / 1000)
+      'tier': message.sub_plan === 'Prime' ? 'Prime' : 'Tier ' + (parseInt(message.sub_plan) / 1000)
     }
   }
 }


### PR DESCRIPTION
Hi,
Thanks a lot for this nice project.

I'm not sure if the Twitch Channel Subscriptions Event Message changed but, it seems like in the data returned by twitch the key for the sub plan is `sub_plan` now.

Let me know if it's different for you !
Have a great day.